### PR TITLE
Añade encabezados de mañana y tarde en la tabla del horario

### DIFF
--- a/index.php
+++ b/index.php
@@ -587,12 +587,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             <table class="schedule" aria-label="Horario semanal">
                 <thead>
                     <tr>
-                        <th>Día</th>
+                        <th rowspan="2">Día</th>
+                        <th colspan="2">Mañana</th>
+                        <th colspan="2">Tarde</th>
+                        <th rowspan="2">Total</th>
+                    </tr>
+                    <tr>
                         <th>Inicio</th>
                         <th>Fin</th>
                         <th>Inicio</th>
                         <th>Fin</th>
-                        <th>Total</th>
                     </tr>
                 </thead>
                 <tbody>


### PR DESCRIPTION
## Summary
- organiza el encabezado de la tabla de horario semanal en dos niveles
- agrupa las columnas de inicio y fin bajo las cabeceras "Mañana" y "Tarde"

## Testing
- no tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2870410d48328b92836b5a664d8d4