### PR TITLE
Adjust calendar title spacing

### DIFF
--- a/index.php
+++ b/index.php
@@ -175,8 +175,9 @@ if ($isExportRequest) {
         if ($months) {
             $pdf->AddPage();
             $pdf->Ln(8);
-            $pdf->SetFont('Arial', 'B', 12);
-            $pdf->Cell(0, 7, $toPdf('Calendario de prácticas'), 0, 1, 'L');
+            $pdf->SetFont('Arial', 'B', 14);
+            $pdf->Cell(0, 8, $toPdf('Calendario de prácticas'), 0, 1, 'L');
+            $pdf->Ln(3);
 
             $legendItems = [
                 ['type' => 'work',  'label' => 'Empresa'],


### PR DESCRIPTION
## Summary
- enlarge the "Calendario de prácticas" title in the exported PDF
- add additional spacing between the calendar title and legend for better separation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d28d7aae1c8328b1179ed27e9cd01c